### PR TITLE
Fix some typos

### DIFF
--- a/content.md
+++ b/content.md
@@ -365,7 +365,7 @@ A great article that digs more into the mathematics of what happens.
 A great Youtube video by 3Blue1Brown, also explaining the maths of Fourier transforms from an audio perspective.
 
 [A Tale of Math & Art: Creating the Fourier Series Harmonic Circles Visualization](https://alex.miller.im/posts/fourier-series-spinning-circles-visualization/)  
-Another article explaining how you can use epicycles to draw a path, explaing from a linear algerbra perspective.
+Another article explaining how you can use epicycles to draw a path, explained from a linear algebra perspective.
 
 [Fourier transform (Wikipedia)](https://en.wikipedia.org/wiki/Fourier_transform)  
 And of course, the Wikipedia article is pretty good too.


### PR DESCRIPTION
Awesome article! Being able "sound" and hear it deconstructed like that is just kind of magical. 

I spotted a typo. I just changed:

> Another article explaining how you can use epicycles to draw a path, explaing from a linear algerbra perspective.

to

> Another article explaining how you can use epicycles to draw a path, explained from a linear algebra perspective.

Not sure why GitHub is showing the bottom line also changed. 